### PR TITLE
ci: fix openarm-can.pc/OpenArmCANConfig.cmake detection

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,10 +87,10 @@ jobs:
       - name: "Python: Build: pkg-config"
         run: |
           python3 -m pip install \
-            -Csetup-args=--build.pkg-config-path=$PWD/install/lib/pkgconfig \
+            -Csetup-args=--pkg-config-path=$PWD/install/lib/pkgconfig \
             ./python
       - name: "Python: Build: CMake"
         run: |
           python3 -m pip install \
-            -Csetup-args=--build.cmake-prefix-path=$PWD/install \
+            -Csetup-args=--cmake-prefix-path=$PWD/install \
             ./python


### PR DESCRIPTION
I think that we need `build.` because we need to set search path on build machine but `--build.{pkg-config-path,cmake-prefix-path}` don't work with Meson 1.9.0...