### PR TITLE
Fix Docker image name

### DIFF
--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -63,7 +63,7 @@ class OpenArmCANPackageTask < PackageTask
   end
 
   def docker_image(os, architecture)
-    "ghcr.io/#{github_repository.gsub(/"_"/, "-")}-package:#{super}"
+    "ghcr.io/#{github_repository.gsub("_", "-")}-package:#{super}"
   end
 end
 


### PR DESCRIPTION
We want to use "-" not "_":

```diff
-ghcr.io/enactic/openarm_can-package
+ghcr.io/enactic/openarm-can-package
```