### PR TITLE
debian: clarify buildsystem

### DIFF
--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -17,11 +17,10 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:
-	dh $@
+	dh $@ --buildsystem=cmake+ninja
 
 override_dh_auto_configure:
 	dh_auto_configure \
-		--buildsystem=cmake+ninja \
 		-- \
 		-DBUILD_SHARED_LIBS=ON \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
Just refactoring. This does not change the behavior.

This is the common style, and it makes it more explicit which build system is in use.