### PR TITLE
packages: add missing python3-numpy dependency

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -33,5 +33,6 @@ openarm-can-configure-socketcan-4-arms -h
 openarm-can-diagnosis -h
 openarm-can-motor-check -h
 openarm-can-set-zero -h
+openarm-can-zero-position-calibration -h
 
 python3 -c "import openarm_can"

--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -81,6 +81,7 @@ Depends:
  iproute2,
  python3,
  python3-can,
+ python3-numpy,
  python3-openarm-can (= ${binary:Version}),
 Description: Utility tools for OpenArm CAN configuration
  OpenArm CAN Library is a communication bridge between high-level


### PR DESCRIPTION
`openarm-can-zero-position-calibration` is part of the openarm-can-utils package but errors out with:

```
ModuleNotFoundError: No module named 'numpy'
```

Because python3-numpy is missing from Depends. Add it.