### PR TITLE
Add support for velocity control mode

### DIFF
--- a/include/openarm/damiao_motor/dm_motor_control.hpp
+++ b/include/openarm/damiao_motor/dm_motor_control.hpp
@@ -61,6 +61,10 @@ struct PosVelParam {
     double dq;
 };
 
+struct VelParam {
+    double dq;  // Target velocity in rad/s.
+};
+
 struct PosForceParam {
     double q;   // Position command in rad.
     double dq;  // Absolute speed limit in rad/s, scaled by 100 into uint16 when packed.
@@ -75,6 +79,7 @@ public:
     static CANPacket create_mit_control_command(const Motor& motor, const MITParam& mit_param);
     static CANPacket create_posvel_control_command(const Motor& motor,
                                                    const PosVelParam& posvel_param);
+    static CANPacket create_vel_control_command(const Motor& motor, const VelParam& vel_param);
     static CANPacket create_posforce_control_command(const Motor& motor,
                                                      const PosForceParam& posforce_param);
     static CANPacket create_set_control_mode_command(const Motor& motor, ControlMode mode);
@@ -86,6 +91,8 @@ private:
                                                       const MITParam& mit_param);
     static std::vector<uint8_t> pack_posvel_control_data(MotorType motor_type,
                                                          const PosVelParam& posvel_param);
+    static std::vector<uint8_t> pack_vel_control_data(MotorType motor_type,
+                                                      const VelParam& vel_param);
     static std::vector<uint8_t> pack_posforce_control_data(MotorType motor_type,
                                                            const PosForceParam& posforce_param);
 

--- a/include/openarm/damiao_motor/dm_motor_device_collection.hpp
+++ b/include/openarm/damiao_motor/dm_motor_device_collection.hpp
@@ -58,6 +58,10 @@ public:
     void posvel_control_one(int i, const PosVelParam& posvel_param);
     void posvel_control_all(const std::vector<PosVelParam>& posvel_params);
 
+    // Vel control operation
+    void vel_control_one(int i, const VelParam& vel_param);
+    void vel_control_all(const std::vector<VelParam>& vel_params);
+
     // PosForce control operation
     void posforce_control_one(int i, const PosForceParam& posforce_param);
     void posforce_control_all(const std::vector<PosForceParam>& posforce_params);

--- a/python/examples/test_vel.py
+++ b/python/examples/test_vel.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Enactic, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import openarm_can as oa
+import time
+
+# Create OpenArm instance
+arm = oa.OpenArm("can0", True)
+
+# Initialize arm motors
+motor_types = [oa.MotorType.DM4310]
+send_ids = [0x24]
+recv_ids = [0x34]
+control_modes = [oa.ControlMode.VEL]
+arm.init_arm_motors(motor_types, send_ids, recv_ids, control_modes)
+
+# Enable motors
+arm.enable_all()
+arm.recv_all()
+
+# VelParam(dq)
+#   dq : target velocity (rad/s)
+arm.set_callback_mode_all(oa.CallbackMode.STATE)
+arm.get_arm().vel_control_all([oa.VelParam(1.0)])
+arm.recv_all()
+
+# Read motor velocity every 0.1s for 30 iterations
+for _ in range(30):
+    arm.refresh_all()
+    arm.recv_all()
+    for motor in arm.get_arm().get_motors():
+        print(motor.get_velocity())
+    for motor in arm.get_gripper().get_motors():
+        print(motor.get_velocity())
+    time.sleep(0.1)
+
+# Command zero velocity before disabling
+arm.get_arm().vel_control_all([oa.VelParam(0.0)])
+arm.recv_all()
+
+arm.disable_all()
+arm.recv_all()

--- a/python/examples/test_vel.py
+++ b/python/examples/test_vel.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Enactic, Inc.
+# Copyright 2026 Enactic, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import openarm_can as oa
 import time
 

--- a/python/src/openarm_can.cpp
+++ b/python/src/openarm_can.cpp
@@ -189,6 +189,14 @@ NB_MODULE(openarm_can, m) {
         .def_rw("q", &PosVelParam::q)
         .def_rw("dq", &PosVelParam::dq);
 
+    // VelParam struct
+    nb::class_<VelParam>(m, "VelParam")
+        .def(nb::init<>())
+        .def(
+            "__init__", [](VelParam* param, double dq) { new (param) VelParam(VelParam{dq}); },
+            nb::arg("dq"))
+        .def_rw("dq", &VelParam::dq);
+
     // PosForceParam struct
     nb::class_<PosForceParam>(m, "PosForceParam")
         .def(nb::init<>())
@@ -237,6 +245,8 @@ NB_MODULE(openarm_can, m) {
         .def_static("create_posvel_control_command",
                     &CanPacketEncoder::create_posvel_control_command, nb::arg("motor"),
                     nb::arg("posvel_param"))
+        .def_static("create_vel_control_command", &CanPacketEncoder::create_vel_control_command,
+                    nb::arg("motor"), nb::arg("vel_param"))
         .def_static("create_posforce_control_command",
                     &CanPacketEncoder::create_posforce_control_command, nb::arg("motor"),
                     nb::arg("posforce_param"))
@@ -400,6 +410,9 @@ NB_MODULE(openarm_can, m) {
              nb::arg("posvel_param"))
         .def("posvel_control_all", &DMDeviceCollection::posvel_control_all,
              nb::arg("posvel_params"))
+        .def("vel_control_one", &DMDeviceCollection::vel_control_one, nb::arg("index"),
+             nb::arg("vel_param"))
+        .def("vel_control_all", &DMDeviceCollection::vel_control_all, nb::arg("vel_params"))
         .def("posforce_control_one", &DMDeviceCollection::posforce_control_one, nb::arg("index"),
              nb::arg("posforce_param"))
         .def("posforce_control_all", &DMDeviceCollection::posforce_control_all,

--- a/src/openarm/damiao_motor/dm_motor_control.cpp
+++ b/src/openarm/damiao_motor/dm_motor_control.cpp
@@ -50,7 +50,8 @@ CANPacket CanPacketEncoder::create_posvel_control_command(const Motor& motor,
 CANPacket CanPacketEncoder::create_vel_control_command(const Motor& motor,
                                                        const VelParam& vel_param) {
     // velocity mode needs extra 0x200.
-    // See also: https://damiao.enactic.ai/en/products/hardware/dm-j4340p-2ec-v1.0/#speed-mode-control-frame
+    // See also:
+    // https://damiao.enactic.ai/en/products/hardware/dm-j4340p-2ec-v1.0/#speed-mode-control-frame
     return {motor.get_send_can_id() + 0x200,
             pack_vel_control_data(motor.get_motor_type(), vel_param)};
 }
@@ -166,7 +167,8 @@ std::vector<uint8_t> CanPacketEncoder::pack_posvel_control_data(
 std::vector<uint8_t> CanPacketEncoder::pack_vel_control_data([[maybe_unused]] MotorType motor_type,
                                                              const VelParam& vel_param) {
     // Velocity mode frame: D[0:3] = v_des as a little-endian float (4 bytes).
-    // See also: https://damiao.enactic.ai/en/products/hardware/dm-j4340p-2ec-v1.0/#speed-mode-control-frame
+    // See also:
+    // https://damiao.enactic.ai/en/products/hardware/dm-j4340p-2ec-v1.0/#speed-mode-control-frame
     auto vb = float_to_uint8s(static_cast<float>(vel_param.dq));
     return {vb[0], vb[1], vb[2], vb[3]};
 }

--- a/src/openarm/damiao_motor/dm_motor_control.cpp
+++ b/src/openarm/damiao_motor/dm_motor_control.cpp
@@ -49,7 +49,8 @@ CANPacket CanPacketEncoder::create_posvel_control_command(const Motor& motor,
 
 CANPacket CanPacketEncoder::create_vel_control_command(const Motor& motor,
                                                        const VelParam& vel_param) {
-    // velocity mode needs extra 0x200
+    // velocity mode needs extra 0x200.
+    // See also: https://damiao.enactic.ai/en/products/hardware/dm-j4340p-2ec-v1.0/#speed-mode-control-frame
     return {motor.get_send_can_id() + 0x200,
             pack_vel_control_data(motor.get_motor_type(), vel_param)};
 }
@@ -165,6 +166,7 @@ std::vector<uint8_t> CanPacketEncoder::pack_posvel_control_data(
 std::vector<uint8_t> CanPacketEncoder::pack_vel_control_data([[maybe_unused]] MotorType motor_type,
                                                              const VelParam& vel_param) {
     // Velocity mode frame: D[0:3] = v_des as a little-endian float (4 bytes).
+    // See also: https://damiao.enactic.ai/en/products/hardware/dm-j4340p-2ec-v1.0/#speed-mode-control-frame
     auto vb = float_to_uint8s(static_cast<float>(vel_param.dq));
     return {vb[0], vb[1], vb[2], vb[3]};
 }

--- a/src/openarm/damiao_motor/dm_motor_control.cpp
+++ b/src/openarm/damiao_motor/dm_motor_control.cpp
@@ -47,6 +47,13 @@ CANPacket CanPacketEncoder::create_posvel_control_command(const Motor& motor,
             pack_posvel_control_data(motor.get_motor_type(), posvel_param)};
 }
 
+CANPacket CanPacketEncoder::create_vel_control_command(const Motor& motor,
+                                                       const VelParam& vel_param) {
+    // velocity mode needs extra 0x200
+    return {motor.get_send_can_id() + 0x200,
+            pack_vel_control_data(motor.get_motor_type(), vel_param)};
+}
+
 CANPacket CanPacketEncoder::create_posforce_control_command(const Motor& motor,
                                                             const PosForceParam& posforce_param) {
     // pos force mode needs extra 0x300
@@ -153,6 +160,13 @@ std::vector<uint8_t> CanPacketEncoder::pack_posvel_control_data(
 
     // Pack into 8 bytes: [pos(4)][vel(4)]
     return {pb[0], pb[1], pb[2], pb[3], vb[0], vb[1], vb[2], vb[3]};
+}
+
+std::vector<uint8_t> CanPacketEncoder::pack_vel_control_data([[maybe_unused]] MotorType motor_type,
+                                                             const VelParam& vel_param) {
+    // Velocity mode frame: D[0:3] = v_des as a little-endian float (4 bytes).
+    auto vb = float_to_uint8s(static_cast<float>(vel_param.dq));
+    return {vb[0], vb[1], vb[2], vb[3]};
 }
 
 std::vector<uint8_t> CanPacketEncoder::pack_posforce_control_data(

--- a/src/openarm/damiao_motor/dm_motor_device_collection.cpp
+++ b/src/openarm/damiao_motor/dm_motor_device_collection.cpp
@@ -147,6 +147,23 @@ void DMDeviceCollection::posvel_control_all(const std::vector<PosVelParam>& posv
     }
 }
 
+void DMDeviceCollection::vel_control_one(int i, const VelParam& vel_param) {
+    auto dm_device = get_dm_devices()[i];
+    if (dm_device->get_control_mode() != ControlMode::VEL) {
+        std::cerr << "WARNING: vel control rejected; motor not in VEL mode." << std::endl;
+        return;
+    }
+    CANPacket vel_cmd =
+        CanPacketEncoder::create_vel_control_command(dm_device->get_motor(), vel_param);
+    send_command_to_device(dm_device, vel_cmd);
+}
+
+void DMDeviceCollection::vel_control_all(const std::vector<VelParam>& vel_params) {
+    for (size_t i = 0; i < vel_params.size(); i++) {
+        vel_control_one(i, vel_params[i]);
+    }
+}
+
 void DMDeviceCollection::posforce_control_one(int i, const PosForceParam& posforce_param) {
     auto dm_device = get_dm_devices()[i];
     if (dm_device->get_control_mode() != ControlMode::POS_FORCE) {


### PR DESCRIPTION
This PR aims to add **velocity control mode** to OpenArm CAN drivers.
The following modifications were made:
- vel parameter, target velocity in rad/s
- `vel_control_one` and `vel_control_all`
- Python binding with the Python test in example

I have tested this in real life and it works.