### PR TITLE
docs(python): fix grammar in unstable-API warning

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -6,4 +6,4 @@ This is the Python bindings of OpenArm CAN library.
 >
 > ⚠️ **WARNING: UNSTABLE API** ⚠️
 > Python bindings are currently a direct low level **temporary port**, and will change **DRASTICALLY**.
-> The interface is may break between versions.Use at your own risk! Discussions on the interface are welcomed.
+> The interface may break between versions. Use at your own risk! Discussions on the interface are welcome.


### PR DESCRIPTION
## Summary
Fix English in the Python bindings UNSTABLE API banner:
- "is may break" → "may break"
- missing space after period; "welcomed" → "welcome"

Small docs-only; reduces curators having to re-edit the same string later.

## Test plan
- [ ] README renders in GitHub