### PR TITLE
fix DM 4340 table value, VMAX

### DIFF
--- a/include/openarm/damiao_motor/dm_motor_constants.hpp
+++ b/include/openarm/damiao_motor/dm_motor_constants.hpp
@@ -99,7 +99,7 @@ inline constexpr std::array<LimitParam, static_cast<std::size_t>(MotorType::COUN
         {12.5, 50, 5},    // DM3507
         {12.5, 30, 10},   // DM4310
         {12.5, 50, 10},   // DM4310_48V
-        {12.5, 8, 28},    // DM4340
+        {12.5, 10, 28},   // DM4340
         {12.5, 10, 28},   // DM4340_48V
         {12.5, 45, 20},   // DM6006
         {12.5, 45, 40},   // DM8006


### PR DESCRIPTION
This PR aims to fix an issue with the table values in the `dm_motor_constants` header file.

While running in velocity control mode, we noticed a repressive tracking that was consistently equal to 0.8

<img width="614" height="246" alt="Screenshot from 2026-07-16 16-59-43" src="https://github.com/user-attachments/assets/f2786483-9c04-432a-b434-effa5c710bb7" />

Then when checking the velocity max of an actual DM 4340P motor, it is listed on the hardware at 10 rad/s. (Same for DM 4340). In its current state, the driver is suppressing velocity commands on these motors by a factor of 8/10 = 0.8. So this PR makes the one line change to match the drivers to the actual hardware.

```
==================================================
 MOTOR ID: 0x28 (Response ID: 0x38)
==================================================
Parameter                     R/W  Type      Range               Value
--------------------------------------------------------------------------------
Under-Voltage Threshold       RW   float     (10.0, fmax]        15.0000
KT Value (Torque Const)       RW   float     [0.0, fmax]         0.0000
Over-Temp Threshold           RW   float     [80.0, 200)         100.0000
Over-Current Threshold        RW   float     (0.0, 1.0)          0.8000
Acceleration                  RW   float     (0.0, fmax)         2.0000
Deceleration                  RW   float     [-fmax, 0.0)        -2.0000
Max Speed                     RW   float     (0.0, fmax]         600.0000
Master ID                     RW   uint32    [0, 0x7FF]          56
Motor (ESC) ID                RW   uint32    [0, 0x7FF]          40
CAN Timeout                   RW   uint32    [0, 2^32-1]         0
Control Mode                  RW   uint32    [0, 4]              3 (VEL)
Damping Ratio                 RO   float     /                   1.961228e-04
Inertia                       RO   float     /                   1.970401e-05
Hardware Version              RO   uint32    /                   1445998643
Software Version              RO   uint32    /                   892416309
Serial Number                 RO   uint32    /                   1412444213
Number of Pole Pairs          RO   uint32    /                   14
Stator Resistance (Rs)        RO   float     /                   8.403752e-01
Stator Inductance (Ls)        RO   float     /                   3.544803e-04
Rotor Flux                    RO   float     /                   5.157192e-03
Gear Ratio                    RO   float     /                   40.0000
Position Limit (PMAX)         RW   float     (0.0, fmax]         12.5000
Velocity Limit (VMAX)         RW   float     (0.0, fmax]         10.0000
Torque Limit (TMAX)           RW   float     (0.0, fmax]         28.0000
```